### PR TITLE
fix(s3_buckets): actually get bucket region and objectLock details

### DIFF
--- a/internal/utils/s3_buckets.go
+++ b/internal/utils/s3_buckets.go
@@ -160,18 +160,18 @@ func (c *Client) getCachedBucketList() ([]S3BucketData, error) {
 	}
 
 	// Cache is expired or empty, fetch fresh data
-	requrl, err := url.Parse(fmt.Sprintf("%s/api/v4/org/containers", c.EndpointURL))
+	reqUrl, err := url.Parse(fmt.Sprintf("%s/api/v4/org/containers", c.EndpointURL))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request url: %w", err)
 	}
 	// Add query params (See: <storagegrid>/ui/apidocs.html#/containers/get_org_containers
-	qparams := requrl.Query()
+	queryParams := reqUrl.Query()
 	// Add include query param to load region and ObjectLock values
 	// Available values : compliance, region, s3ObjectLock, deleteObjects, crossGridReplication, quotaObjectBytes
-	qparams.Add("include", "region,s3ObjectLock")
-	requrl.RawQuery = qparams.Encode()
+	queryParams.Add("include", "region,s3ObjectLock")
+	reqUrl.RawQuery = queryParams.Encode()
 
-	req, err := http.NewRequest("GET", requrl.String(), nil)
+	req, err := http.NewRequest("GET", reqUrl.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}


### PR DESCRIPTION
## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

Currently the bucket resource and datasource doesn't retreive the region (and objectLock) causing a bucket replacement on every call and the datasource always returns 'us-east-1' for region.

```hcl
  # storagegrid_s3_bucket.bucket must be replaced
-/+ resource "storagegrid_s3_bucket" "bucket" {
      ~ id                  = "sandbox" -> (known after apply)
      ~ region              = "NL" -> "us-east-1" # forces replacement
        # (2 unchanged attributes hidden)
    }
``` 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan
To rollback the changes, only a revert of the commit is required. 
Will cause buckets to be replaced if the state contains an other region than the default.

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
no
