### PR TITLE
Add expired object delete marker option

### DIFF
--- a/docs/data-sources/s3_bucket_lifecycle_configuration.md
+++ b/docs/data-sources/s3_bucket_lifecycle_configuration.md
@@ -76,6 +76,7 @@ Optional:
 
 - `date` (String) Date when objects expire (ISO 8601 format).
 - `days` (Number) Number of days after object creation when the object expires.
+- `expired_object_delete_marker` (Boolean) Indicates whether StorageGrid removes expired object delete markers (delete markers with no noncurrent versions).
 
 
 <a id="nestedblock--rule--filter"></a>

--- a/docs/resources/s3_bucket_lifecycle_configuration.md
+++ b/docs/resources/s3_bucket_lifecycle_configuration.md
@@ -125,6 +125,7 @@ Optional:
 
 - `date` (String) Date when objects expire (ISO 8601 format).
 - `days` (Number) Number of days after object creation when the object expires.
+- `expired_object_delete_marker` (Boolean) Indicates whether StorageGrid removes expired object delete markers (delete markers with no noncurrent versions). Cannot be combined with days or date.
 
 
 <a id="nestedblock--rule--filter"></a>

--- a/docs/resources/s3_bucket_lifecycle_configuration.md
+++ b/docs/resources/s3_bucket_lifecycle_configuration.md
@@ -114,7 +114,7 @@ Required:
 Optional:
 
 - `expiration` (Block, Optional) Expiration settings for current object versions. (see [below for nested schema](#nestedblock--rule--expiration))
-- `filter` (Block, Optional) Filter for the lifecycle rule. (see [below for nested schema](#nestedblock--rule--filter))
+- `filter` (Block, Optional) Filter for the lifecycle rule. Omit this block to apply the rule to all objects. (see [below for nested schema](#nestedblock--rule--filter))
 - `id` (String) Unique identifier for the rule.
 - `noncurrent_version_expiration` (Block, Optional) Expiration settings for noncurrent object versions. (see [below for nested schema](#nestedblock--rule--noncurrent_version_expiration))
 

--- a/internal/provider/access_keys_resource.go
+++ b/internal/provider/access_keys_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/group_data_source.go
+++ b/internal/provider/group_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/json_plan_modifier.go
+++ b/internal/provider/json_plan_modifier.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_data_source.go
+++ b/internal/provider/s3_bucket_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_lifecycle_configuration_data_source.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_data_source.go
@@ -50,8 +50,9 @@ type LifecycleFilterDataSourceModel struct {
 
 // LifecycleExpirationDataSourceModel represents expiration settings.
 type LifecycleExpirationDataSourceModel struct {
-	Days types.Int64  `tfsdk:"days"`
-	Date types.String `tfsdk:"date"`
+	Days                      types.Int64  `tfsdk:"days"`
+	Date                      types.String `tfsdk:"date"`
+	ExpiredObjectDeleteMarker types.Bool   `tfsdk:"expired_object_delete_marker"`
 }
 
 // LifecycleNoncurrentVersionDataSourceModel represents noncurrent version expiration settings.
@@ -107,6 +108,11 @@ func (d *S3BucketLifecycleConfigurationDataSource) Schema(ctx context.Context, r
 								},
 								"date": schema.StringAttribute{
 									Description: "Date when objects expire (ISO 8601 format).",
+									Computed:    true,
+									Optional:    true,
+								},
+								"expired_object_delete_marker": schema.BoolAttribute{
+									Description: "Indicates whether StorageGrid removes expired object delete markers (delete markers with no noncurrent versions).",
 									Computed:    true,
 									Optional:    true,
 								},
@@ -191,6 +197,11 @@ func (d *S3BucketLifecycleConfigurationDataSource) Read(ctx context.Context, req
 				ruleModel.Expiration.Date = types.StringValue(rule.Expiration.Date)
 			} else {
 				ruleModel.Expiration.Date = types.StringNull()
+			}
+			if rule.Expiration.ExpiredObjectDeleteMarker != nil {
+				ruleModel.Expiration.ExpiredObjectDeleteMarker = types.BoolValue(*rule.Expiration.ExpiredObjectDeleteMarker)
+			} else {
+				ruleModel.Expiration.ExpiredObjectDeleteMarker = types.BoolNull()
 			}
 		}
 

--- a/internal/provider/s3_bucket_lifecycle_configuration_data_source.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_lifecycle_configuration_resource.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_resource.go
@@ -55,8 +55,9 @@ type LifecycleFilterResourceModel struct {
 
 // LifecycleExpirationResourceModel represents expiration settings.
 type LifecycleExpirationResourceModel struct {
-	Days types.Int64  `tfsdk:"days"`
-	Date types.String `tfsdk:"date"`
+	Days                      types.Int64  `tfsdk:"days"`
+	Date                      types.String `tfsdk:"date"`
+	ExpiredObjectDeleteMarker types.Bool   `tfsdk:"expired_object_delete_marker"`
 }
 
 // LifecycleNoncurrentVersionResourceModel represents noncurrent version expiration settings.
@@ -126,6 +127,10 @@ func (r *S3BucketLifecycleConfigurationResource) Schema(ctx context.Context, req
 									Description: "Date when objects expire (ISO 8601 format).",
 									Optional:    true,
 								},
+								"expired_object_delete_marker": schema.BoolAttribute{
+									Description: "Indicates whether StorageGrid removes expired object delete markers (delete markers with no noncurrent versions). Cannot be combined with days or date.",
+									Optional:    true,
+								},
 							},
 						},
 						"noncurrent_version_expiration": schema.SingleNestedBlock{
@@ -161,22 +166,13 @@ func (r *S3BucketLifecycleConfigurationResource) Configure(ctx context.Context, 
 	r.client = client
 }
 
-func (r *S3BucketLifecycleConfigurationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan S3BucketLifecycleConfigurationResourceModel
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	bucketName := plan.BucketName.ValueString()
-
-	// Convert Terraform model to API model
+// buildLifecycleConfiguration converts the Terraform rule models into the API model.
+func buildLifecycleConfiguration(rules []LifecycleRuleResourceModel) *utils.LifecycleConfiguration {
 	lifecycleConfig := &utils.LifecycleConfiguration{
-		Rules: make([]utils.Rule, len(plan.Rules)),
+		Rules: make([]utils.Rule, len(rules)),
 	}
 
-	for i, rule := range plan.Rules {
+	for i, rule := range rules {
 		apiRule := utils.Rule{
 			ID:     rule.ID.ValueString(),
 			Status: rule.Status.ValueString(),
@@ -191,13 +187,17 @@ func (r *S3BucketLifecycleConfigurationResource) Create(ctx context.Context, req
 
 		// Handle expiration - only set if at least one field has a value
 		// This prevents creating empty XML elements which the minio-go library (>=7.0.98) rejects
-		if rule.Expiration != nil && (!rule.Expiration.Days.IsNull() || !rule.Expiration.Date.IsNull()) {
+		if rule.Expiration != nil && (!rule.Expiration.Days.IsNull() || !rule.Expiration.Date.IsNull() || !rule.Expiration.ExpiredObjectDeleteMarker.IsNull()) {
 			apiRule.Expiration = &utils.Expiration{}
 			if !rule.Expiration.Days.IsNull() {
 				apiRule.Expiration.Days = int(rule.Expiration.Days.ValueInt64())
 			}
 			if !rule.Expiration.Date.IsNull() {
 				apiRule.Expiration.Date = rule.Expiration.Date.ValueString()
+			}
+			if !rule.Expiration.ExpiredObjectDeleteMarker.IsNull() {
+				marker := rule.Expiration.ExpiredObjectDeleteMarker.ValueBool()
+				apiRule.Expiration.ExpiredObjectDeleteMarker = &marker
 			}
 		}
 
@@ -210,6 +210,71 @@ func (r *S3BucketLifecycleConfigurationResource) Create(ctx context.Context, req
 
 		lifecycleConfig.Rules[i] = apiRule
 	}
+
+	return lifecycleConfig
+}
+
+// mapLifecycleRules converts the API model into the Terraform rule models.
+func mapLifecycleRules(lifecycleConfig *utils.LifecycleConfiguration) []LifecycleRuleResourceModel {
+	var rules []LifecycleRuleResourceModel
+	for _, rule := range lifecycleConfig.Rules {
+		ruleModel := LifecycleRuleResourceModel{
+			ID:     types.StringValue(rule.ID),
+			Status: types.StringValue(rule.Status),
+		}
+
+		// Handle filter
+		if rule.Filter != nil {
+			ruleModel.Filter = &LifecycleFilterResourceModel{
+				Prefix: types.StringValue(rule.Filter.Prefix),
+			}
+		}
+
+		// Handle expiration
+		if rule.Expiration != nil {
+			ruleModel.Expiration = &LifecycleExpirationResourceModel{}
+			if rule.Expiration.Days > 0 {
+				ruleModel.Expiration.Days = types.Int64Value(int64(rule.Expiration.Days))
+			} else {
+				ruleModel.Expiration.Days = types.Int64Null()
+			}
+			if rule.Expiration.Date != "" {
+				ruleModel.Expiration.Date = types.StringValue(rule.Expiration.Date)
+			} else {
+				ruleModel.Expiration.Date = types.StringNull()
+			}
+			if rule.Expiration.ExpiredObjectDeleteMarker != nil {
+				ruleModel.Expiration.ExpiredObjectDeleteMarker = types.BoolValue(*rule.Expiration.ExpiredObjectDeleteMarker)
+			} else {
+				ruleModel.Expiration.ExpiredObjectDeleteMarker = types.BoolNull()
+			}
+		}
+
+		// Handle noncurrent version expiration
+		if rule.NoncurrentVersionExpiration != nil {
+			ruleModel.NoncurrentVersionExpiration = &LifecycleNoncurrentVersionResourceModel{
+				NoncurrentDays: types.Int64Value(int64(rule.NoncurrentVersionExpiration.NoncurrentDays)),
+			}
+		}
+
+		rules = append(rules, ruleModel)
+	}
+
+	return rules
+}
+
+func (r *S3BucketLifecycleConfigurationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan S3BucketLifecycleConfigurationResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	bucketName := plan.BucketName.ValueString()
+
+	// Convert Terraform model to API model
+	lifecycleConfig := buildLifecycleConfiguration(plan.Rules)
 
 	err := r.client.PutS3BucketLifecycleConfiguration(bucketName, lifecycleConfig)
 	if err != nil {
@@ -246,46 +311,7 @@ func (r *S3BucketLifecycleConfigurationResource) Read(ctx context.Context, req r
 	}
 
 	// Convert API model to Terraform model
-	var rules []LifecycleRuleResourceModel
-	for _, rule := range lifecycleConfig.Rules {
-		ruleModel := LifecycleRuleResourceModel{
-			ID:     types.StringValue(rule.ID),
-			Status: types.StringValue(rule.Status),
-		}
-
-		// Handle filter
-		if rule.Filter != nil {
-			ruleModel.Filter = &LifecycleFilterResourceModel{
-				Prefix: types.StringValue(rule.Filter.Prefix),
-			}
-		}
-
-		// Handle expiration
-		if rule.Expiration != nil {
-			ruleModel.Expiration = &LifecycleExpirationResourceModel{}
-			if rule.Expiration.Days > 0 {
-				ruleModel.Expiration.Days = types.Int64Value(int64(rule.Expiration.Days))
-			} else {
-				ruleModel.Expiration.Days = types.Int64Null()
-			}
-			if rule.Expiration.Date != "" {
-				ruleModel.Expiration.Date = types.StringValue(rule.Expiration.Date)
-			} else {
-				ruleModel.Expiration.Date = types.StringNull()
-			}
-		}
-
-		// Handle noncurrent version expiration
-		if rule.NoncurrentVersionExpiration != nil {
-			ruleModel.NoncurrentVersionExpiration = &LifecycleNoncurrentVersionResourceModel{
-				NoncurrentDays: types.Int64Value(int64(rule.NoncurrentVersionExpiration.NoncurrentDays)),
-			}
-		}
-
-		rules = append(rules, ruleModel)
-	}
-
-	state.Rules = rules
+	state.Rules = mapLifecycleRules(lifecycleConfig)
 	state.ID = types.StringValue(bucketName)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -302,44 +328,7 @@ func (r *S3BucketLifecycleConfigurationResource) Update(ctx context.Context, req
 	bucketName := plan.BucketName.ValueString()
 
 	// Convert Terraform model to API model
-	lifecycleConfig := &utils.LifecycleConfiguration{
-		Rules: make([]utils.Rule, len(plan.Rules)),
-	}
-
-	for i, rule := range plan.Rules {
-		apiRule := utils.Rule{
-			ID:     rule.ID.ValueString(),
-			Status: rule.Status.ValueString(),
-		}
-
-		// Handle filter
-		if rule.Filter != nil {
-			apiRule.Filter = &utils.Filter{
-				Prefix: rule.Filter.Prefix.ValueString(),
-			}
-		}
-
-		// Handle expiration - only set if at least one field has a value
-		// This prevents creating empty XML elements which the minio-go library (>=7.0.98) rejects
-		if rule.Expiration != nil && (!rule.Expiration.Days.IsNull() || !rule.Expiration.Date.IsNull()) {
-			apiRule.Expiration = &utils.Expiration{}
-			if !rule.Expiration.Days.IsNull() {
-				apiRule.Expiration.Days = int(rule.Expiration.Days.ValueInt64())
-			}
-			if !rule.Expiration.Date.IsNull() {
-				apiRule.Expiration.Date = rule.Expiration.Date.ValueString()
-			}
-		}
-
-		// Handle noncurrent version expiration
-		if rule.NoncurrentVersionExpiration != nil {
-			apiRule.NoncurrentVersionExpiration = &utils.NoncurrentVersionExpiration{
-				NoncurrentDays: int(rule.NoncurrentVersionExpiration.NoncurrentDays.ValueInt64()),
-			}
-		}
-
-		lifecycleConfig.Rules[i] = apiRule
-	}
+	lifecycleConfig := buildLifecycleConfiguration(plan.Rules)
 
 	err := r.client.PutS3BucketLifecycleConfiguration(bucketName, lifecycleConfig)
 	if err != nil {
@@ -390,50 +379,10 @@ func (r *S3BucketLifecycleConfigurationResource) ImportState(ctx context.Context
 		return
 	}
 
-	// Convert API model to Terraform model
-	var rules []LifecycleRuleResourceModel
-	for _, rule := range lifecycleConfig.Rules {
-		ruleModel := LifecycleRuleResourceModel{
-			ID:     types.StringValue(rule.ID),
-			Status: types.StringValue(rule.Status),
-		}
-
-		// Handle filter
-		if rule.Filter != nil {
-			ruleModel.Filter = &LifecycleFilterResourceModel{
-				Prefix: types.StringValue(rule.Filter.Prefix),
-			}
-		}
-
-		// Handle expiration
-		if rule.Expiration != nil {
-			ruleModel.Expiration = &LifecycleExpirationResourceModel{}
-			if rule.Expiration.Days > 0 {
-				ruleModel.Expiration.Days = types.Int64Value(int64(rule.Expiration.Days))
-			} else {
-				ruleModel.Expiration.Days = types.Int64Null()
-			}
-			if rule.Expiration.Date != "" {
-				ruleModel.Expiration.Date = types.StringValue(rule.Expiration.Date)
-			} else {
-				ruleModel.Expiration.Date = types.StringNull()
-			}
-		}
-
-		// Handle noncurrent version expiration
-		if rule.NoncurrentVersionExpiration != nil {
-			ruleModel.NoncurrentVersionExpiration = &LifecycleNoncurrentVersionResourceModel{
-				NoncurrentDays: types.Int64Value(int64(rule.NoncurrentVersionExpiration.NoncurrentDays)),
-			}
-		}
-
-		rules = append(rules, ruleModel)
-	}
-
 	// Set the imported lifecycle configuration in state
 	state := S3BucketLifecycleConfigurationResourceModel{
 		BucketName: types.StringValue(bucketName),
-		Rules:      rules,
+		Rules:      mapLifecycleRules(lifecycleConfig),
 		ID:         types.StringValue(bucketName),
 	}
 

--- a/internal/provider/s3_bucket_lifecycle_configuration_resource.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_resource.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/team-fenrir/terraform-provider-storagegrid/internal/utils"
 )
@@ -130,6 +132,12 @@ func (r *S3BucketLifecycleConfigurationResource) Schema(ctx context.Context, req
 								"expired_object_delete_marker": schema.BoolAttribute{
 									Description: "Indicates whether StorageGrid removes expired object delete markers (delete markers with no noncurrent versions). Cannot be combined with days or date.",
 									Optional:    true,
+									Validators: []validator.Bool{
+										boolvalidator.ConflictsWith(
+											path.MatchRelative().AtParent().AtName("days"),
+											path.MatchRelative().AtParent().AtName("date"),
+										),
+									},
 								},
 							},
 						},

--- a/internal/provider/s3_bucket_lifecycle_configuration_resource.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_lifecycle_configuration_resource.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_resource.go
@@ -67,6 +67,42 @@ type LifecycleNoncurrentVersionResourceModel struct {
 	NoncurrentDays types.Int64 `tfsdk:"noncurrent_days"`
 }
 
+// nonEmptyFilterValidator ensures that a declared filter block specifies a
+// non-empty prefix. StorageGrid always stores (and returns) a <Filter> element,
+// so an empty prefix is indistinguishable from no filter on read — both mean
+// "apply to all objects". Allowing an empty filter block would canonicalize to
+// no filter in state and produce a perpetual diff, so we require it to be
+// omitted instead.
+type nonEmptyFilterValidator struct{}
+
+func (v nonEmptyFilterValidator) Description(ctx context.Context) string {
+	return "filter block must specify a non-empty prefix; omit the filter block to apply the rule to all objects"
+}
+
+func (v nonEmptyFilterValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v nonEmptyFilterValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	// Block omitted entirely (the supported "match all" form), or not yet known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	prefix, ok := req.ConfigValue.Attributes()["prefix"].(types.String)
+	if !ok || prefix.IsUnknown() {
+		return
+	}
+
+	if prefix.IsNull() || prefix.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Filter Configuration",
+			"The filter block must specify a non-empty prefix. To apply the rule to all objects, omit the filter block entirely.",
+		)
+	}
+}
+
 func (r *S3BucketLifecycleConfigurationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_s3_bucket_lifecycle_configuration"
 }
@@ -110,12 +146,15 @@ func (r *S3BucketLifecycleConfigurationResource) Schema(ctx context.Context, req
 					},
 					Blocks: map[string]schema.Block{
 						"filter": schema.SingleNestedBlock{
-							Description: "Filter for the lifecycle rule.",
+							Description: "Filter for the lifecycle rule. Omit this block to apply the rule to all objects.",
 							Attributes: map[string]schema.Attribute{
 								"prefix": schema.StringAttribute{
 									Description: "Object key prefix that identifies the objects to which the rule applies.",
 									Optional:    true,
 								},
+							},
+							Validators: []validator.Object{
+								nonEmptyFilterValidator{},
 							},
 						},
 						"expiration": schema.SingleNestedBlock{

--- a/internal/provider/s3_bucket_lifecycle_configuration_resource_test.go
+++ b/internal/provider/s3_bucket_lifecycle_configuration_resource_test.go
@@ -1,0 +1,562 @@
+// Copyright IBM Corp. 2025, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/team-fenrir/terraform-provider-storagegrid/internal/utils"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestBuildLifecycleConfiguration(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []LifecycleRuleResourceModel
+		want  *utils.LifecycleConfiguration
+	}{
+		{
+			name:  "no rules",
+			rules: nil,
+			want:  &utils.LifecycleConfiguration{Rules: []utils.Rule{}},
+		},
+		{
+			name: "minimal rule without optional blocks",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled"},
+				},
+			},
+		},
+		{
+			name: "rule with filter prefix",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Filter: &LifecycleFilterResourceModel{
+						Prefix: types.StringValue("logs/"),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:     "rule-1",
+						Status: "Enabled",
+						Filter: &utils.Filter{Prefix: "logs/"},
+					},
+				},
+			},
+		},
+		{
+			name: "expiration with days",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Value(30),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:         "rule-1",
+						Status:     "Enabled",
+						Expiration: &utils.Expiration{Days: 30},
+					},
+				},
+			},
+		},
+		{
+			name: "expiration with date",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringValue("2026-01-01T00:00:00Z"),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:         "rule-1",
+						Status:     "Enabled",
+						Expiration: &utils.Expiration{Date: "2026-01-01T00:00:00Z"},
+					},
+				},
+			},
+		},
+		{
+			name: "expiration with expired_object_delete_marker true",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolValue(true),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:         "rule-1",
+						Status:     "Enabled",
+						Expiration: &utils.Expiration{ExpiredObjectDeleteMarker: boolPtr(true)},
+					},
+				},
+			},
+		},
+		{
+			name: "expiration with expired_object_delete_marker false is still set",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolValue(false),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:         "rule-1",
+						Status:     "Enabled",
+						Expiration: &utils.Expiration{ExpiredObjectDeleteMarker: boolPtr(false)},
+					},
+				},
+			},
+		},
+		{
+			name: "empty expiration block produces no expiration",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled"},
+				},
+			},
+		},
+		{
+			name: "noncurrent version expiration",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					NoncurrentVersionExpiration: &LifecycleNoncurrentVersionResourceModel{
+						NoncurrentDays: types.Int64Value(7),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:                          "rule-1",
+						Status:                      "Enabled",
+						NoncurrentVersionExpiration: &utils.NoncurrentVersionExpiration{NoncurrentDays: 7},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple rules preserve order and per-rule shape",
+			rules: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Filter: &LifecycleFilterResourceModel{Prefix: types.StringValue("logs/")},
+				},
+				{
+					ID:     types.StringValue("rule-2"),
+					Status: types.StringValue("Disabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Value(90),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+			want: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{
+						ID:     "rule-1",
+						Status: "Enabled",
+						Filter: &utils.Filter{Prefix: "logs/"},
+					},
+					{
+						ID:         "rule-2",
+						Status:     "Disabled",
+						Expiration: &utils.Expiration{Days: 90},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildLifecycleConfiguration(tt.rules)
+			assertLifecycleConfigEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestMapLifecycleRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *utils.LifecycleConfiguration
+		want   []LifecycleRuleResourceModel
+	}{
+		{
+			name:   "no rules",
+			config: &utils.LifecycleConfiguration{},
+			want:   nil,
+		},
+		{
+			name: "minimal rule",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{{ID: "rule-1", Status: "Enabled"}},
+			},
+			want: []LifecycleRuleResourceModel{
+				{ID: types.StringValue("rule-1"), Status: types.StringValue("Enabled")},
+			},
+		},
+		{
+			name: "rule with filter",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled", Filter: &utils.Filter{Prefix: "logs/"}},
+				},
+			},
+			want: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Filter: &LifecycleFilterResourceModel{Prefix: types.StringValue("logs/")},
+				},
+			},
+		},
+		{
+			name: "expiration with days only nulls date and marker",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled", Expiration: &utils.Expiration{Days: 30}},
+				},
+			},
+			want: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Value(30),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+		},
+		{
+			name: "expiration with expired_object_delete_marker",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled", Expiration: &utils.Expiration{ExpiredObjectDeleteMarker: boolPtr(true)}},
+				},
+			},
+			want: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolValue(true),
+					},
+				},
+			},
+		},
+		{
+			// mapLifecycleRules treats Expiration.Days <= 0 as "unset" and maps it
+			// to a null Int64. This documents that asymmetry: an Expiration that is
+			// present but carries no positive Days/Date/marker yields all-null fields.
+			name: "expiration with zero days maps to null days",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled", Expiration: &utils.Expiration{Days: 0}},
+				},
+			},
+			want: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					Expiration: &LifecycleExpirationResourceModel{
+						Days:                      types.Int64Null(),
+						Date:                      types.StringNull(),
+						ExpiredObjectDeleteMarker: types.BoolNull(),
+					},
+				},
+			},
+		},
+		{
+			name: "noncurrent version expiration",
+			config: &utils.LifecycleConfiguration{
+				Rules: []utils.Rule{
+					{ID: "rule-1", Status: "Enabled", NoncurrentVersionExpiration: &utils.NoncurrentVersionExpiration{NoncurrentDays: 7}},
+				},
+			},
+			want: []LifecycleRuleResourceModel{
+				{
+					ID:     types.StringValue("rule-1"),
+					Status: types.StringValue("Enabled"),
+					NoncurrentVersionExpiration: &LifecycleNoncurrentVersionResourceModel{
+						NoncurrentDays: types.Int64Value(7),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapLifecycleRules(tt.config)
+			assertRuleModelsEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestBuildAndMapRoundTrip ensures a configuration survives a build -> map
+// round trip without unexpected drift for the common field combinations.
+func TestBuildAndMapRoundTrip(t *testing.T) {
+	original := []LifecycleRuleResourceModel{
+		{
+			ID:     types.StringValue("rule-1"),
+			Status: types.StringValue("Enabled"),
+			Filter: &LifecycleFilterResourceModel{Prefix: types.StringValue("logs/")},
+			Expiration: &LifecycleExpirationResourceModel{
+				Days:                      types.Int64Value(30),
+				Date:                      types.StringNull(),
+				ExpiredObjectDeleteMarker: types.BoolNull(),
+			},
+			NoncurrentVersionExpiration: &LifecycleNoncurrentVersionResourceModel{
+				NoncurrentDays: types.Int64Value(7),
+			},
+		},
+	}
+
+	roundTripped := mapLifecycleRules(buildLifecycleConfiguration(original))
+	assertRuleModelsEqual(t, roundTripped, original)
+}
+
+func TestNonEmptyFilterValidator(t *testing.T) {
+	ctx := context.Background()
+	attrTypes := map[string]attr.Type{"prefix": types.StringType}
+
+	tests := []struct {
+		name      string
+		value     types.Object
+		wantError bool
+	}{
+		{
+			name:      "null filter object is valid",
+			value:     types.ObjectNull(attrTypes),
+			wantError: false,
+		},
+		{
+			name:      "unknown filter object is valid",
+			value:     types.ObjectUnknown(attrTypes),
+			wantError: false,
+		},
+		{
+			name: "non-empty prefix is valid",
+			value: types.ObjectValueMust(attrTypes, map[string]attr.Value{
+				"prefix": types.StringValue("logs/"),
+			}),
+			wantError: false,
+		},
+		{
+			name: "empty prefix is invalid",
+			value: types.ObjectValueMust(attrTypes, map[string]attr.Value{
+				"prefix": types.StringValue(""),
+			}),
+			wantError: true,
+		},
+		{
+			name: "null prefix is invalid",
+			value: types.ObjectValueMust(attrTypes, map[string]attr.Value{
+				"prefix": types.StringNull(),
+			}),
+			wantError: true,
+		},
+		{
+			name: "unknown prefix is valid",
+			value: types.ObjectValueMust(attrTypes, map[string]attr.Value{
+				"prefix": types.StringUnknown(),
+			}),
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := validator.ObjectRequest{
+				Path:        path.Root("filter"),
+				ConfigValue: tt.value,
+			}
+			resp := &validator.ObjectResponse{}
+
+			nonEmptyFilterValidator{}.ValidateObject(ctx, req, resp)
+
+			if got := resp.Diagnostics.HasError(); got != tt.wantError {
+				t.Fatalf("HasError() = %v, want %v (diagnostics: %v)", got, tt.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// assertLifecycleConfigEqual compares two API lifecycle configurations field by field.
+func assertLifecycleConfigEqual(t *testing.T, got, want *utils.LifecycleConfiguration) {
+	t.Helper()
+
+	if len(got.Rules) != len(want.Rules) {
+		t.Fatalf("rule count = %d, want %d", len(got.Rules), len(want.Rules))
+	}
+
+	for i := range want.Rules {
+		g, w := got.Rules[i], want.Rules[i]
+		if g.ID != w.ID || g.Status != w.Status {
+			t.Errorf("rule[%d] ID/Status = (%q, %q), want (%q, %q)", i, g.ID, g.Status, w.ID, w.Status)
+		}
+
+		assertFilterEqual(t, i, g.Filter, w.Filter)
+		assertExpirationEqual(t, i, g.Expiration, w.Expiration)
+		assertNoncurrentEqual(t, i, g.NoncurrentVersionExpiration, w.NoncurrentVersionExpiration)
+	}
+}
+
+func assertFilterEqual(t *testing.T, i int, got, want *utils.Filter) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("rule[%d] Filter presence = %v, want %v", i, got != nil, want != nil)
+		return
+	}
+	if got != nil && got.Prefix != want.Prefix {
+		t.Errorf("rule[%d] Filter.Prefix = %q, want %q", i, got.Prefix, want.Prefix)
+	}
+}
+
+func assertExpirationEqual(t *testing.T, i int, got, want *utils.Expiration) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("rule[%d] Expiration presence = %v, want %v", i, got != nil, want != nil)
+		return
+	}
+	if got == nil {
+		return
+	}
+	if got.Days != want.Days {
+		t.Errorf("rule[%d] Expiration.Days = %d, want %d", i, got.Days, want.Days)
+	}
+	if got.Date != want.Date {
+		t.Errorf("rule[%d] Expiration.Date = %q, want %q", i, got.Date, want.Date)
+	}
+	switch {
+	case (got.ExpiredObjectDeleteMarker == nil) != (want.ExpiredObjectDeleteMarker == nil):
+		t.Errorf("rule[%d] Expiration.ExpiredObjectDeleteMarker presence = %v, want %v",
+			i, got.ExpiredObjectDeleteMarker != nil, want.ExpiredObjectDeleteMarker != nil)
+	case got.ExpiredObjectDeleteMarker != nil && *got.ExpiredObjectDeleteMarker != *want.ExpiredObjectDeleteMarker:
+		t.Errorf("rule[%d] Expiration.ExpiredObjectDeleteMarker = %v, want %v",
+			i, *got.ExpiredObjectDeleteMarker, *want.ExpiredObjectDeleteMarker)
+	}
+}
+
+func assertNoncurrentEqual(t *testing.T, i int, got, want *utils.NoncurrentVersionExpiration) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("rule[%d] NoncurrentVersionExpiration presence = %v, want %v", i, got != nil, want != nil)
+		return
+	}
+	if got != nil && got.NoncurrentDays != want.NoncurrentDays {
+		t.Errorf("rule[%d] NoncurrentVersionExpiration.NoncurrentDays = %d, want %d", i, got.NoncurrentDays, want.NoncurrentDays)
+	}
+}
+
+// assertRuleModelsEqual compares two slices of Terraform rule models field by field.
+func assertRuleModelsEqual(t *testing.T, got, want []LifecycleRuleResourceModel) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("rule count = %d, want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		g, w := got[i], want[i]
+		if !g.ID.Equal(w.ID) || !g.Status.Equal(w.Status) {
+			t.Errorf("rule[%d] ID/Status = (%v, %v), want (%v, %v)", i, g.ID, g.Status, w.ID, w.Status)
+		}
+
+		if (g.Filter == nil) != (w.Filter == nil) {
+			t.Errorf("rule[%d] Filter presence = %v, want %v", i, g.Filter != nil, w.Filter != nil)
+		} else if g.Filter != nil && !g.Filter.Prefix.Equal(w.Filter.Prefix) {
+			t.Errorf("rule[%d] Filter.Prefix = %v, want %v", i, g.Filter.Prefix, w.Filter.Prefix)
+		}
+
+		if (g.Expiration == nil) != (w.Expiration == nil) {
+			t.Errorf("rule[%d] Expiration presence = %v, want %v", i, g.Expiration != nil, w.Expiration != nil)
+		} else if g.Expiration != nil {
+			if !g.Expiration.Days.Equal(w.Expiration.Days) {
+				t.Errorf("rule[%d] Expiration.Days = %v, want %v", i, g.Expiration.Days, w.Expiration.Days)
+			}
+			if !g.Expiration.Date.Equal(w.Expiration.Date) {
+				t.Errorf("rule[%d] Expiration.Date = %v, want %v", i, g.Expiration.Date, w.Expiration.Date)
+			}
+			if !g.Expiration.ExpiredObjectDeleteMarker.Equal(w.Expiration.ExpiredObjectDeleteMarker) {
+				t.Errorf("rule[%d] Expiration.ExpiredObjectDeleteMarker = %v, want %v",
+					i, g.Expiration.ExpiredObjectDeleteMarker, w.Expiration.ExpiredObjectDeleteMarker)
+			}
+		}
+
+		if (g.NoncurrentVersionExpiration == nil) != (w.NoncurrentVersionExpiration == nil) {
+			t.Errorf("rule[%d] NoncurrentVersionExpiration presence = %v, want %v",
+				i, g.NoncurrentVersionExpiration != nil, w.NoncurrentVersionExpiration != nil)
+		} else if g.NoncurrentVersionExpiration != nil &&
+			!g.NoncurrentVersionExpiration.NoncurrentDays.Equal(w.NoncurrentVersionExpiration.NoncurrentDays) {
+			t.Errorf("rule[%d] NoncurrentVersionExpiration.NoncurrentDays = %v, want %v",
+				i, g.NoncurrentVersionExpiration.NoncurrentDays, w.NoncurrentVersionExpiration.NoncurrentDays)
+		}
+	}
+}

--- a/internal/provider/s3_bucket_object_lock_configuration_data_source.go
+++ b/internal/provider/s3_bucket_object_lock_configuration_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_object_lock_configuration_resource.go
+++ b/internal/provider/s3_bucket_object_lock_configuration_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_resource.go
+++ b/internal/provider/s3_bucket_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_versioning_data_source.go
+++ b/internal/provider/s3_bucket_versioning_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/s3_bucket_versioning_resource.go
+++ b/internal/provider/s3_bucket_versioning_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package provider

--- a/internal/utils/access_keys.go
+++ b/internal/utils/access_keys.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/auxiliary.go
+++ b/internal/utils/auxiliary.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/groups.go
+++ b/internal/utils/groups.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/groups_test.go
+++ b/internal/utils/groups_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/s3_buckets.go
+++ b/internal/utils/s3_buckets.go
@@ -578,8 +578,9 @@ type Filter struct {
 
 // Expiration represents expiration settings for current versions.
 type Expiration struct {
-	Days int    `xml:"Days,omitempty"`
-	Date string `xml:"Date,omitempty"`
+	Days                      int    `xml:"Days,omitempty"`
+	Date                      string `xml:"Date,omitempty"`
+	ExpiredObjectDeleteMarker *bool  `xml:"ExpiredObjectDeleteMarker,omitempty"`
 }
 
 // NoncurrentVersionExpiration represents expiration settings for noncurrent versions.
@@ -789,8 +790,11 @@ func (c *Client) GetS3BucketLifecycleConfiguration(bucketName string) (*Lifecycl
 				Status: string(rule.Status),
 			}
 
-			// Handle filter
-			if rule.Filter != nil && rule.Filter.Prefix != nil {
+			// Handle filter. StorageGrid returns an empty <Filter> element for rules
+			// created without one; an empty prefix matches all objects and is
+			// equivalent to no filter, so don't materialize it into state (otherwise a
+			// config that omits the filter block produces a perpetual diff).
+			if rule.Filter != nil && aws.ToString(rule.Filter.Prefix) != "" {
 				lifecycleRule.Filter = &Filter{
 					Prefix: aws.ToString(rule.Filter.Prefix),
 				}
@@ -804,6 +808,9 @@ func (c *Client) GetS3BucketLifecycleConfiguration(bucketName string) (*Lifecycl
 				}
 				if rule.Expiration.Date != nil {
 					lifecycleRule.Expiration.Date = rule.Expiration.Date.Format("2006-01-02T15:04:05.000Z")
+				}
+				if rule.Expiration.ExpiredObjectDeleteMarker != nil {
+					lifecycleRule.Expiration.ExpiredObjectDeleteMarker = rule.Expiration.ExpiredObjectDeleteMarker
 				}
 			}
 
@@ -845,11 +852,15 @@ func (c *Client) PutS3BucketLifecycleConfiguration(bucketName string, lifecycleC
 				Status: types.ExpirationStatus(rule.Status),
 			}
 
-			// Handle filter
-			if rule.Filter != nil {
+			// Handle filter. The v2 lifecycle schema requires every rule to carry a
+			// <Filter> element; omitting it results in a MalformedXML error. An empty
+			// filter matches all objects, so send one whenever no prefix is configured.
+			if rule.Filter != nil && rule.Filter.Prefix != "" {
 				awsRule.Filter = &types.LifecycleRuleFilter{
 					Prefix: aws.String(rule.Filter.Prefix),
 				}
+			} else {
+				awsRule.Filter = &types.LifecycleRuleFilter{}
 			}
 
 			// Handle expiration
@@ -862,6 +873,9 @@ func (c *Client) PutS3BucketLifecycleConfiguration(bucketName string, lifecycleC
 					if date, err := time.Parse("2006-01-02T15:04:05.000Z", rule.Expiration.Date); err == nil {
 						awsRule.Expiration.Date = aws.Time(date)
 					}
+				}
+				if rule.Expiration.ExpiredObjectDeleteMarker != nil {
+					awsRule.Expiration.ExpiredObjectDeleteMarker = rule.Expiration.ExpiredObjectDeleteMarker
 				}
 			}
 

--- a/internal/utils/s3_buckets.go
+++ b/internal/utils/s3_buckets.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/internal/utils/users.go
+++ b/internal/utils/users.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2025, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build generate


### PR DESCRIPTION
Looking at the bucket lifecycle rules. Expire deletemarker is false but there was no option to set it.

<img width="558" height="233" alt="image" src="https://github.com/user-attachments/assets/b2c3a844-9d0a-41e9-ac58-56d07629d30c" />

With this PR that option has been added (and tested).

<img width="640" height="247" alt="image" src="https://github.com/user-attachments/assets/7219bae4-c734-4da6-a3d8-4e181eb49844" />

Furthermore, the functions mapLifecycleRules and buildLifecycleConfiguration have been added to remove some duplication.